### PR TITLE
Debounce search input

### DIFF
--- a/old-selector.js
+++ b/old-selector.js
@@ -1,0 +1,67 @@
+class OldSelector {
+  constructor(selector, prefix) {
+    this.prefix = prefix
+    this.prefixed = selector.prefixed(this.prefix)
+    this.regexp = selector.regexp(this.prefix)
+
+    this.prefixeds = selector
+      .possible()
+      .map(x => [selector.prefixed(x), selector.regexp(x)])
+
+    this.unprefixed = selector.name
+    this.nameRegexp = selector.regexp()
+  }
+
+  /**
+   * Is rule a hack without unprefixed version bottom
+   */
+  isHack(rule) {
+    let index = rule.parent.index(rule) + 1
+    let rules = rule.parent.nodes
+
+    while (index < rules.length) {
+      let before = rules[index].selector
+      if (!before) {
+        return true
+      }
+
+      if (before.includes(this.unprefixed) && before.match(this.nameRegexp)) {
+        return false
+      }
+
+      let some = false
+      for (let [string, regexp] of this.prefixeds) {
+        if (before.includes(string) && before.match(regexp)) {
+          some = true
+          break
+        }
+      }
+
+      if (!some) {
+        return true
+      }
+
+      index += 1
+    }
+
+    return true
+  }
+
+  /**
+   * Does rule contain an unnecessary prefixed selector
+   */
+  check(rule) {
+    if (!rule.selector.includes(this.prefixed)) {
+      return false
+    }
+    if (!rule.selector.match(this.regexp)) {
+      return false
+    }
+    if (this.isHack(rule)) {
+      return false
+    }
+    return true
+  }
+}
+
+module.exports = OldSelector


### PR DESCRIPTION
Reduce unnecessary API calls and re-renders by adding a 300ms debounce to the SearchInput component. This change introduces a debounced handler (lodash.debounce) and updates unit tests to assert delayed calls.