### PR TITLE
Improve button focus styles

### DIFF
--- a/WindowRole.js
+++ b/WindowRole.js
@@ -1,0 +1,12 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports["default"] = void 0;
+var WindowRole = {
+  relatedConcepts: [],
+  type: 'window'
+};
+var _default = WindowRole;
+exports["default"] = _default;


### PR DESCRIPTION
Add a visible, non-layout-shifting focus style to primary and icon buttons to improve keyboard accessibility. Updated CSS to use :focus-visible with a 3px accent outline and outline-offset, and ensured existing box-shadow focus styles don't cause layout shift.