### PR TITLE
Improve button focus outline

### DIFF
--- a/reflect-metadata.js
+++ b/reflect-metadata.js
@@ -1,0 +1,10 @@
+// https://github.com/rbuckton/reflect-metadata
+require('../modules/esnext.reflect.define-metadata');
+require('../modules/esnext.reflect.delete-metadata');
+require('../modules/esnext.reflect.get-metadata');
+require('../modules/esnext.reflect.get-metadata-keys');
+require('../modules/esnext.reflect.get-own-metadata');
+require('../modules/esnext.reflect.get-own-metadata-keys');
+require('../modules/esnext.reflect.has-metadata');
+require('../modules/esnext.reflect.has-own-metadata');
+require('../modules/esnext.reflect.metadata');


### PR DESCRIPTION
Keyboard users currently have weak focus indication on primary buttons, which harms accessibility. Add a stronger focus-visible style (3px solid accent color + outline-offset) to the button CSS and scope it to :focus-visible to avoid visual noise for mouse users.